### PR TITLE
Feature: status exporter service

### DIFF
--- a/bashapps/Readme.md
+++ b/bashapps/Readme.md
@@ -5,3 +5,4 @@ This directory contains bash scripts for temporary or alternative solutions to p
 ## Dir: status_exporter
 
 A temporary or alternative server that provides access to server data for the bot.
+Read more here: [status_exporter/Readme.md](status_exporter/Readme.md)

--- a/bashapps/status_exporter/Readme.md
+++ b/bashapps/status_exporter/Readme.md
@@ -1,0 +1,64 @@
+# JSON Status Exporter
+## Purpose
+This set of scripts is designed to provide certain metrics from my servers to my telegram bot. These metrics can also be collected and stored in a DB (I intend to use InfluxDB for this purpose) for further processing and study (in Grafana in my case).
+
+## Why bash?
+I didn't want to write this code in Python, because Python consumes a lot of resources (and I am extremely limited in them because I use a free service), and I also don't want to install Python directly on the server. I would like to use Golang, but I didn't want to spend a lot of time (I thought I would do everything on bash in a day, but I spent 4 days on it (1 full day to solve some JSON formatting problem, and 3 days on average 2 hours a day on other problems.))
+
+## Warning
+* `netcat` is not intended to be used as a web server all the time and may have vulnerabilities that could allow an attacker to gain access to your server. So make sure that no one other than the necessary applications has access to the port on which `netcat` is listening.
+* I also do not exclude the possibility that my code may not be stable, so if you run it, you do so at your own risk.
+
+## Installation and running
+### General
+* create directory `/opt/status_exporter/`
+* copy all files to this directory
+    ```bash
+    cp * /opt/status_exporter/
+    ```
+* copy `default.env.sh` and rename copy to `.env.sh`
+* edit `.env.sh` to specify your preferences
+
+### systemd
+* create user `sexport` and add him in group `docker` if you have docker installed on your server
+    ```bash
+    sudo useradd -r -s /usr/sbin/nologin sexport
+    sudo usermod -aG docker sexport
+    ```
+* give permissions to the user to have access to app dir
+    ```bash
+        chown -R sexport /opt/status_exporter
+        chmod -R u+rx /opt/status_exporter
+    ```
+* set up autostart 
+    * copy or move `statusexporter.service` to `/etc/systemd/system/`
+        ```bash
+        sudo cp statusexporter.service /etc/systemd/system/
+        ```
+    * Reload the systemd configuration, enable service autostart and start the service by running the following commands:
+        ```bash
+        sudo systemctl daemon-reload
+        sudo systemctl enable statusexporter.service
+        sudo systemctl start statusexporter.service
+        ```
+* to stop service use
+    ```bash
+    sudo systemctl stop statusexporter.service
+    ```
+
+### non service mode
+* edit `.env.sh` and set PID_FILE_DIR to be equal `"."`
+* start with command:
+    ```bash
+    nohup /opt/status_exporter/startexporter.sh &
+    ```
+* stop with command:
+    ```bash
+    /opt/status_exporter/stopexporter.sh
+    ```
+
+## ToDo:
+- add more descriptions in functions
+- create install script
+- maybe: create whiptail based interface to control script (install/uninstall, run, etc)
+- add network metrics support

--- a/bashapps/status_exporter/default.env.sh
+++ b/bashapps/status_exporter/default.env.sh
@@ -16,3 +16,11 @@ BASE_64=0
 ## If for some reason you need to run more than 1 instance of the program,
 ## just change the name here.
 APP_NAME="statusexporter"
+
+## Change this path if you don't want to install the application as a service.
+## Example:
+# PID_FILE_DIR="/opt/status_exporter"
+## or if you wat to use current directory
+# PID_FILE_DIR="."
+## this option is recommended for running as a service
+PID_FILE_DIR="/var/run"

--- a/bashapps/status_exporter/startexporter.sh
+++ b/bashapps/status_exporter/startexporter.sh
@@ -16,8 +16,8 @@ source $(dirname "$0")/websrv.lib.sh    # Lib of functions to run netcat web ser
 
 ## Preliminary check of launch conditions.
 ## check PID file existence
-if [ -f /var/run/${APP_NAME}.pid ]; then
-    echo "$APP_NAME ERROR: PID file (/var/run/${APP_NAME}.pid) already exists. Therefore, the process is already running or was not terminated correctly." >&2
+if [ -f ${PID_FILE_DIR}/${APP_NAME}.pid ]; then
+    echo "$APP_NAME ERROR: PID file (${PID_FILE_DIR}/${APP_NAME}.pid) already exists. Therefore, the process is already running or was not terminated correctly." >&2
     exit 1
 else
     ## check if port is busy
@@ -26,7 +26,7 @@ else
         exit 1
     fi
     ## save pid to file
-    echo $$ > /var/run/${APP_NAME}.pid
+    echo $$ > ${PID_FILE_DIR}/${APP_NAME}.pid || exit 1
 fi
 
 exporter_data(){

--- a/bashapps/status_exporter/statusexporter.service
+++ b/bashapps/status_exporter/statusexporter.service
@@ -4,10 +4,13 @@ Documentation=https://github.com/Blase-ssa/telegram_status_bot/blob/main/bashapp
 After=network.target auditd.service
 
 [Service]
+User=sexport
 ExecStart=/opt/status_exporter/startexporter.sh
 ExecStop==/opt/status_exporter/stopexporter.sh
+PIDFile=/var/run/statusexporter.pid
 KillMode=process
-Restart=on-failure
-Type=forking #notify
-RuntimeDirectoryMode=0755
+Restart=always
+Type=notify
 
+[Install]
+WantedBy=multi-user.target

--- a/bashapps/status_exporter/stopexporter.sh
+++ b/bashapps/status_exporter/stopexporter.sh
@@ -2,7 +2,7 @@
 # run this script to stop netcat server
 
 # 
-if [ $SRV_PORT -le 0 ]; then
+if [[ $SRV_PORT -le 0 ]]; then
     if [ -f .env.sh ]; then
         source $(dirname "$0")/.env.sh
     else
@@ -11,11 +11,11 @@ if [ $SRV_PORT -le 0 ]; then
 fi
 
 ## check PID file existence
-if [ -f /var/run/${APP_NAME}.pid ]; then
+if [ -f ${PID_FILE_DIR}/${APP_NAME}.pid ]; then
     ## get PID from file --> kill PID --> remove PID file --> send request to server to stop current iteration
-    pid=$(cat /var/run/${APP_NAME}.pid)
+    pid=$(cat ${PID_FILE_DIR}/${APP_NAME}.pid)
     kill $pid
-    rm /var/run/${APP_NAME}.pid
+    rm ${PID_FILE_DIR}/${APP_NAME}.pid
     nc -vz $SRV_ADDR $SRV_PORT
 else
     echo "PID-file not found"


### PR DESCRIPTION
Add:
- description to functions
- processor count
- load average
- RAM and Swap information
- function pc_get_all to allow getting of all available information in 1 function
- web server
- pc_check_requirement to check requirement
- exporter_data - now return correct json data for PC and Docker
- pc_get_common_data - now return time in UNIX seconds
- time zone in start time
- processing of RENEW_TIMEOUT
- ability to specify interface for web server
- shutdown script and functionality for server
- systemd unit file
- Readme.md for status exporter
- move todo to from change.log to Readme.md since this stage of development is complete, the service is ready and now you can collect data from it.

Fix:
- return in bash must return a numeric value (fixed or removed in all functions)
- fix all functions in pc.lib.sh

Update:
- descriptions for functions
- time format for general data